### PR TITLE
fix warming (Auto-application to `()` is deprecated.  )

### DIFF
--- a/server/app/utils/Util.scala
+++ b/server/app/utils/Util.scala
@@ -54,7 +54,7 @@ object Util {
       case (name, value) => connection.setRequestProperty(name, value)
     })
 
-    val s = Source.fromInputStream(connection.getInputStream).getLines.mkString("\n")
+    val s = Source.fromInputStream(connection.getInputStream).getLines().mkString("\n")
 
     s
   }


### PR DESCRIPTION
Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method getLines, or remove the empty argument list from its definition 
In Scala 3, an unapplied method like this will be eta-expanded into a function.

val s = Source.fromInputStream(connection.getInputStream).getLines.mkString("\n")
